### PR TITLE
fix: conditional to include rn-tester and react-native-gradle-plugin in settings.gradle.kts.

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,7 +17,7 @@ include(":ReactAndroid", ":ReactAndroid:hermes-engine", ":ReactAndroid:external-
 
 // If the ./packages folder exists, then we're inside the React Native repository.
 // If not, a users is consuming this project for a build from source.
-if (File("./packages").exists()) {
+if (File("${rootDir}/packages").exists()) {
   include(":packages:rn-tester:android:app")
   // Include this to enable codegen Gradle plugin.
   includeBuild("packages/react-native-gradle-plugin/")


### PR DESCRIPTION


<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Relative path in conditional IF in settings.gradle.kts doesn't work when it try to build (`yarn install-android-jsc`) a package that isn't in root dir and needs of react-native-gradle-plugin or when it try to run rn-tester.

When trying to compile rn-tester (`yarn install-android-jsc` command) the error below:

```Shell
arthur@assuncao  ~/projects/react-native-test/react-native/packages/rn-tester   main  yarn install-android-jsc
yarn run v1.22.19
$ ../../gradlew :packages:rn-tester:android:app:installJscDebug
Starting a Gradle Daemon (subsequent builds will be faster)

FAILURE: Build failed with an exception.

* What went wrong:
Project directory '/home/arthur/projects/react-native-test/react-native/packages/rn-tester' is not part of the build defined by settings file '/home/arthur/projects/react-native-test/react-native/settings.gradle.kts'. If this is an unrelated build, it must have its own settings file.

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.

* Get more help at https://help.gradle.org

BUILD FAILED in 8s
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.

```
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

[INTERNAL] [FIXED] - Fix conditional to include rn-tester and react-native-gradle-plugin in settings.gradle.kts.

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Execute rn-tester like [(RN-Tester Readme)](https://github.com/facebook/react-native/blob/main/packages/rn-tester/README.md).

After my changes, the output of `yarn install-android-jsc` is:
```Shell
[... many of the other tasks completed above]
> Task :packages:rn-tester:android:app:compileJscDebugJavaWithJavac
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.

> Task :packages:rn-tester:android:app:stripJscDebugDebugSymbols
Unable to strip the following libraries, packaging them as they are: libicu_common.so.

> Task :packages:rn-tester:android:app:installJscDebug
Installing APK 'app-jsc-arm64-v8a-debug.apk' on 'ASUS_Z01KD - 8.0.0' for :packages:rn-tester:android:app:jsc-debug
Installed on 1 device.

BUILD SUCCESSFUL in 31m 53s
121 actionable tasks: 121 executed
Done in 1913.92s.

```


